### PR TITLE
Added dataset cache

### DIFF
--- a/get-started/walkthrough.ipynb
+++ b/get-started/walkthrough.ipynb
@@ -158,7 +158,7 @@
     "import transformers\n",
     "import datasets\n",
     "\n",
-    "dataset_rootdir = Path(\"/graphcore/vit_model_training\").absolute()"
+    "dataset_rootdir = Path(\"/tmp/vit_model_training\").absolute()"
    ]
   },
   {
@@ -184,6 +184,35 @@
     "\n",
     "# Path to Data_Entry_2017_v2020.csv\n",
     "label_file = dataset_rootdir / 'Data_Entry_2017_v2020.csv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have made datasets and label files readily available in `/graphcore` so you won't have to download them. This data folder is a read-only folder accessible in all IPU runtimes.\n",
+    "\n",
+    "You will need to link the available dataset to your target dataset directory to be able to use it. \n",
+    "\n",
+    "Linking of the data in the `/graphcore` folder into a writeable path is preferrable because it is a read-only folder, and mistakenly trying to write into it would cause an error.\n",
+    "\n",
+    "If you want to store data permanently, and make it accessible across runtimes, use [Paperspace Datasets](https://docs.paperspace.com/gradient/data/).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Create the dataset directory\n",
+    "!mkdir -p $dataset_rootdir\n",
+    "\n",
+    "# Create a link from the relevant data source to the target dataset directory\n",
+    "!ln -s /graphcore/vit_model_training/Data_Entry_2017_v2020.csv $dataset_rootdir\n",
+    "!ln -s /graphcore/vit_model_training/images/ $images_dir"
    ]
   },
   {
@@ -257,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[[\"Image Index\", \"labels\"]].rename(columns={\"Image Index\": \"file_name\"}).to_json(images_dir / 'metadata.jsonl', orient='records', lines=True)"
+    "data[[\"Image Index\", \"labels\"]].rename(columns={\"Image Index\": \"file_name\"}).to_json(dataset_rootdir / 'metadata.jsonl', orient='records', lines=True)"
    ]
   },
   {


### PR DESCRIPTION
What this does:
- Unblocks ViT in Runtimes
- uses /tmp for dataset_rootdir 
- create symlink of Chest XRay from /graphcore into dataset_rootdir
- update path to write metadata json into writeable dataset_rootdir

To Do:
- Update code to use os env to define hard-coded paths